### PR TITLE
PR 명령어 토큰 설정 가이드 개선 및 보안 주의사항 추가

### DIFF
--- a/plugins/git-commands/commands/pr.md
+++ b/plugins/git-commands/commands/pr.md
@@ -182,13 +182,7 @@ gh auth status
 옵션 2:
   git config --global github.token "your_token_here"
 
-옵션 3:
-  export GITHUB_PERSONAL_ACCESS_TOKEN="your_token_here"
-  (지속성을 위해 ~/.bashrc 또는 ~/.zshrc에 추가)
-
-옵션 4:
-  ~/.config/claude/github-token 생성
-  토큰을 여기에 붙여넣기
+**보안 주의사항**: Personal Access Token은 비밀번호와 같이 안전하게 관리해야 합니다. 가능한 경우 GitHub CLI를 사용하거나 .env 파일을 저장소에 push하지 않도록 주의해주세요.
 
 토큰 설정 후 다시 시도: /pr
 ```


### PR DESCRIPTION
## Related Issue

-

## Describe your changes

PR 명령어의 GitHub 토큰 설정 가이드를 개선하고 보안 주의사항을 추가했습니다.

- 불필요한 토큰 설정 옵션 제거 (옵션 3, 4)
  - 환경 변수 export 방식 제거
  - ~/.config/claude/github-token 방식 제거
  - GitHub CLI와 git config 방식으로 통일

- 보안 주의사항 추가
  - Personal Access Token의 안전한 관리 필요성 명시
  - GitHub CLI 사용 권장
  - .env 파일 저장소 push 금지 안내

## Request

- 토큰 설정 방법이 명확하게 전달되는지 확인 부탁드립니다
- 보안 주의사항이 적절한지 검토 부탁드립니다