### PR TITLE
feat: add package-evaluator plugin (0.x experimental)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,12 @@
       "description": "코드 검증 및 사이드 이펙트 분석",
       "source": "./plugins/code-verifier-agents",
       "homepage": "https://github.com/NaverPayDev/naverpay-plugins/tree/main/plugins/code-verifier-agents"
+    },
+    {
+      "name": "naverpay-package-evaluator",
+      "description": "npm 패키지 도입 전 npmx.dev 데이터 기반 자동 평가",
+      "source": "./plugins/package-evaluator",
+      "homepage": "https://github.com/NaverPayDev/naverpay-plugins/tree/main/plugins/package-evaluator"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ UI를 통해 개별 marketplace의 업데이트를 설정/진행할 수 있습�
 
 - [changeset-commands](./plugins/changeset-commands)
 - [git-commands](./plugins/git-commands)
+- [naverpay-package-evaluator](./plugins/package-evaluator/)

--- a/plugins/package-evaluator/.claude-plugin/plugin.json
+++ b/plugins/package-evaluator/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "naverpay-package-evaluator",
+  "description": "Evaluates npm packages before installation using npmx.dev data",
+  "author": {
+    "name": "NaverPayDev"
+  },
+  "repository": "https://github.com/NaverPayDev/naverpay-plugins",
+  "keywords": ["naverpay", "claude-plugin", "claude", "plugin", "npm", "package", "evaluate"]
+}

--- a/plugins/package-evaluator/.claude-plugin/plugin.json
+++ b/plugins/package-evaluator/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "naverpay-package-evaluator",
+  "version": "0.1.0",
   "description": "Evaluates npm packages before installation using npmx.dev data",
   "author": {
     "name": "NaverPayDev"

--- a/plugins/package-evaluator/README.md
+++ b/plugins/package-evaluator/README.md
@@ -1,0 +1,47 @@
+# Package Evaluator Plugin
+
+npm 패키지 도입 전 npmx.dev 데이터를 기반으로 자동 평가합니다.
+
+## 주요 기능
+
+- npmx.dev에서 CDP(Chrome DevTools Protocol)를 통해 패키지 메트릭 자동 수집
+- 단일 패키지 평가 및 패키지 간 비교 지원
+- 신뢰성, 보안, 라이센스 기준 자동 판정
+- PR 기재용 도입 근거 템플릿 생성
+
+## 설치
+
+```
+/plugin install naverpay-package-evaluator@naverpay-plugins
+```
+
+## 사용법
+
+```bash
+# 단일 패키지 평가
+/naverpay-package-evaluator:evaluate-package lodash-es
+
+# 여러 패키지 비교 평가
+/naverpay-package-evaluator:evaluate-package lodash-es es-toolkit
+```
+
+## 사전 요구사항
+
+- Google Chrome 또는 Chromium이 설치되어 있어야 합니다
+- Chrome을 CDP 모드로 실행해야 합니다:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --headless=new --remote-debugging-port=9222 --no-first-run --disable-gpu --no-sandbox
+```
+
+- Node.js 22+ (글로벌 WebSocket 빌트인 사용)
+
+## 수집 메트릭
+
+| 카테고리 | 항목 |
+|---|---|
+| Performance | Package Size, Install Size, Direct Deps, Total Deps |
+| Health | Downloads/wk, Likes, Published, Deprecated |
+| Compatibility | Engines, Types, Module Format |
+| Security & Compliance | License, Vulnerabilities |

--- a/plugins/package-evaluator/commands/evaluate-package.md
+++ b/plugins/package-evaluator/commands/evaluate-package.md
@@ -1,0 +1,205 @@
+---
+description: npm 패키지 도입 전 npmx.dev 데이터를 기반으로 평가합니다
+allowed-tools: Bash(node:*), Bash(find:*), Bash(gh:*), Bash(npm view:*), Read, Glob, Grep
+---
+
+## ⛔ 절대 금지
+
+- 평가 없이 패키지를 설치하지 말 것
+- 평가 결과에 "by Claude Code", "Generated with Claude" 등 Claude 관련 문구를 **절대 포함하지 말 것**
+
+# 패키지 도입 평가
+
+npm 패키지 도입 여부를 판단하기 위해 npmx.dev에서 메트릭을 수집하고 평가합니다.
+
+## 인자
+
+- `$ARGUMENTS`: 평가할 패키지명 (공백 구분, 1개 이상)
+- 예: `/evaluate-package lodash-es` 또는 `/evaluate-package lodash-es @naverpay/hidash`
+
+## 사전조건
+
+Chrome/Chromium이 CDP 모드로 실행 중이어야 합니다. 실행 중이 아니라면 사용자에게 아래 명령어를 안내하고 실행을 요청합니다:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --headless=new --remote-debugging-port=9222 --no-first-run --disable-gpu --no-sandbox
+```
+
+## 프로세스
+
+### 1. 스크립트 실행으로 메트릭 수집
+
+플러그인 디렉토리 내 `scripts/scrape-npmx.mjs` 스크립트를 실행하여 npmx.dev에서 데이터를 수집합니다.
+
+```bash
+# 플러그인 스크립트 경로 찾기
+find ~/.claude -name "scrape-npmx.mjs" -path "*/package-evaluator/*" 2>/dev/null | head -1
+
+# 스크립트 실행 (패키지명을 인자로 전달)
+node <스크립트경로>/scrape-npmx.mjs $ARGUMENTS
+```
+
+스크립트가 JSON으로 다음 메트릭을 반환합니다:
+
+| 카테고리 | 항목 |
+|---|---|
+| **Performance** | Package Size, Install Size, Direct Deps, Total Deps |
+| **Health** | Downloads/wk, Likes, Published, Deprecated |
+| **Compatibility** | Engines, Types, Module Format |
+| **Security** | License, Vulnerabilities |
+
+### 2. 기존 설치 패키지 확인
+
+프로젝트의 `package.json`에서 `dependencies`/`devDependencies`를 확인하여, 이미 설치된 패키지로 해결 가능한지 검토합니다.
+
+- 동일 패키지가 이미 설치되어 있는 경우 → 중복 설치 경고
+- 유사 기능의 패키지가 이미 있는 경우 → 기존 패키지 활용 권장
+
+### 3. GitHub 이슈 분석 (가능한 경우)
+
+`npm view <패키지명> repository.url --json`으로 GitHub 저장소 URL을 가져옵니다.
+GitHub 저장소가 확인되면 아래 정보를 추가 수집합니다:
+
+```bash
+# 저장소 기본 정보 (stars, open issues 수)
+gh api repos/{owner}/{repo} --jq '{stars: .stargazers_count, open_issues: .open_issues_count}'
+
+# 최근 이슈 20개 (bug 비율, 응답 속도 파악)
+gh api "repos/{owner}/{repo}/issues?state=all&per_page=20&sort=created&direction=desc" \
+  --jq '.[] | {title, state, labels: [.labels[].name], created_at, closed_at, comments}'
+```
+
+분석 항목:
+
+- **버그 이슈 비율**: 최근 이슈 중 bug/error/fix 라벨 또는 제목에 해당 키워드가 포함된 비율
+- **이슈 응답 속도**: 최근 닫힌 이슈의 생성~종료 평균 기간
+- **방치된 이슈**: 코멘트 0개이고 30일 이상 열려있는 이슈 수
+- GitHub 저장소가 없거나 접근 불가한 경우 이 단계를 건너뜁니다
+
+### 4. 평가 기준 적용
+
+수집된 메트릭을 기준에 대입하여 판정합니다:
+
+#### 즉시 거부 조건 (하나라도 해당되면 ❌)
+
+- 기존 설치된 패키지로 해결 가능
+- License가 GPL 계열 (소스 공개 의무)
+- Deprecated 상태
+- High 이상 심각도의 취약점(Vulnerabilities)이 1건 이상 존재
+
+#### 경고 조건 (⚠️ 주의 필요)
+
+- 마지막 업데이트가 1년 이상 경과
+- 타입 지원 없음 (Types: None)
+- 메인테이너가 1인
+- CJS 전용 (ESM 미지원) — 도입은 가능하나 ESM 지원 대안이 있으면 대안 우선
+- GitHub 이슈 중 버그 비율 50% 이상
+- 이슈 평균 응답 기간 30일 초과
+
+#### 양호 조건 (✅)
+
+- 위 거부/경고 조건 없음
+- MIT / Apache 2.0 / BSD 라이센스
+- ESM 지원 (ESM + CJS 듀얼 포함)
+- TypeScript 타입 지원
+
+### 5. 결과 출력
+
+## 출력 형식
+
+### 단일 패키지 평가
+
+```txt
+📦 패키지 평가: lodash-es
+━━━━━━━━━━━━━━━━━━━━━━━━
+
+📊 수집된 메트릭 (npmx.dev)
+┌─────────────────┬──────────────┐
+│ Package Size    │ 95.2 kB      │
+│ Install Size    │ 633.9 kB     │
+│ Direct Deps     │ 0            │
+│ Total Deps      │ 0            │
+│ Downloads/wk    │ 12,345,678   │
+│ Published       │ Jan 21, 2026 │
+│ Deprecated      │ No           │
+│ Types           │ @types/...   │
+│ Module Format   │ ESM          │
+│ License         │ MIT          │
+│ Vulnerabilities │ 0            │
+└─────────────────┴──────────────┘
+
+🔍 기존 설치 패키지 확인
+- 동일/유사 패키지: 해당 없음
+
+⚖️ 판정: ✅ 도입 가능
+━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### 비교 평가
+
+```txt
+📦 패키지 비교 평가
+━━━━━━━━━━━━━━━━━━━━━━━━
+
+📊 수집된 메트릭 (npmx.dev)
+┌─────────────────┬──────────────┬──────────────────┐
+│                 │ lodash-es    │ es-toolkit       │
+├─────────────────┼──────────────┼──────────────────┤
+│ Package Size    │ 95.2 kB      │ 12.3 kB          │
+│ Install Size    │ 633.9 kB     │ 45.6 kB          │
+│ Direct Deps     │ 0            │ 0                │
+│ Downloads/wk    │ 12,345,678   │ 890,000          │
+│ Types           │ @types/...   │ Built-in         │
+│ Module Format   │ ESM          │ ESM              │
+│ License         │ MIT          │ MIT              │
+│ Vulnerabilities │ 0            │ 0                │
+└─────────────────┴──────────────┴──────────────────┘
+
+⚖️ 비교 판정
+━━━━━━━━━━━━━━━━━━━━━━━━
+es-toolkit 우위:
+- 번들 사이즈 87% 작음
+- 타입 빌트인 지원
+
+lodash-es 우위:
+- 커뮤니티 규모 (다운로드 수)
+- 함수 커버리지 넓음
+
+권장: (메트릭 기반으로 객관적 비교 제시, 최종 선택은 사용자에게 위임)
+```
+
+### 도입 승인 시 PR 템플릿
+
+판정이 ✅인 경우, PR에 붙여넣을 수 있는 도입 근거 템플릿도 함께 출력합니다:
+
+```markdown
+## 라이브러리 도입 근거
+
+- **패키지명**: `example-package`
+- **도입 이유**: (구체적 사유)
+- **주간 다운로드**: X회
+- **마지막 업데이트**: YYYY-MM-DD
+- **번들 사이즈**: X kB (gzip: X kB)
+- **라이센스**: MIT
+- **취약점**: 0건
+- **타입 지원**: ✅ Built-in / @types/...
+```
+
+## 규칙
+
+- 평가 결과는 항상 한국어로 출력
+- 메트릭은 npmx.dev에서 수집한 실제 데이터를 사용 (추측하지 않음)
+- 스크립트 실행 실패 시 사용자에게 오류 내용을 그대로 전달하고 중단
+
+## 스크립트 오류 처리
+
+```txt
+❌ CDP 연결 실패
+
+Chrome/Chromium이 CDP 모드로 실행 중이지 않습니다.
+아래 명령어로 Chrome을 실행한 뒤 다시 시도하세요:
+
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --headless=new --remote-debugging-port=9222 --no-first-run --disable-gpu --no-sandbox
+```

--- a/plugins/package-evaluator/commands/evaluate-package.md
+++ b/plugins/package-evaluator/commands/evaluate-package.md
@@ -31,6 +31,7 @@ Chrome/Chromium이 CDP 모드로 실행 중이어야 합니다. 실행 중이 �
 ### 1. 스크립트 실행으로 메트릭 수집
 
 플러그인 디렉토리 내 `scripts/scrape-npmx.mjs` 스크립트를 실행하여 npmx.dev에서 데이터를 수집합니다.
+스크립트는 DOM 셀렉터 대신 **CDP Accessibility Tree**를 사용하여 CSS 클래스 변경에 영향받지 않습니다.
 
 ```bash
 # 플러그인 스크립트 경로 찾기

--- a/plugins/package-evaluator/scripts/scrape-npmx.mjs
+++ b/plugins/package-evaluator/scripts/scrape-npmx.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+/**
+ * npmx.dev Compare 페이지에서 패키지 메트릭을 CDP로 스크래핑합니다.
+ *
+ * 사전조건:
+ *   Chrome/Chromium이 --remote-debugging-port=9222로 실행 중이어야 합니다.
+ *   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+ *     --headless=new --remote-debugging-port=9222 --no-first-run --disable-gpu --no-sandbox
+ *
+ * 사용법:
+ *   node scrape-npmx.mjs <패키지명> [패키지명2 ...]
+ *
+ * 단일 패키지인 경우 비교 대상으로 react를 더미로 추가하고,
+ * 결과에서 대상 패키지 데이터만 추출합니다.
+ *
+ * 요구사항: Node.js 22+, Chrome/Chromium (9222 포트)
+ *
+ * 출력: JSON (stdout)
+ */
+
+import http from 'node:http'
+
+// --- 설정 ---
+const CDP_PORT = 9222
+const NPMX_COMPARE_URL = 'https://npmx.dev/compare'
+const DUMMY_PACKAGE = 'react'
+const PAGE_LOAD_TIMEOUT = 15_000
+const RENDER_WAIT = 5_000
+
+// --- CDP 통신 ---
+async function getPageWebSocketUrl() {
+    return new Promise((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${CDP_PORT}/json/list`, (res) => {
+            let data = ''
+            res.on('data', (chunk) => (data += chunk))
+            res.on('end', () => {
+                try {
+                    const targets = JSON.parse(data)
+                    const page = targets.find((t) => t.type === 'page')
+                    if (page?.webSocketDebuggerUrl) {
+                        resolve(page.webSocketDebuggerUrl)
+                    } else {
+                        reject(new Error('페이지 타겟을 찾을 수 없습니다'))
+                    }
+                } catch (e) {
+                    reject(new Error(`CDP 응답 파싱 실패: ${e.message}`))
+                }
+            })
+        })
+        req.on('error', (e) => {
+            reject(
+                new Error(
+                    `CDP 연결 실패 (127.0.0.1:${CDP_PORT}). Chrome이 --remote-debugging-port=${CDP_PORT}로 실행 중인지 확인하세요.\n${e.message}`,
+                ),
+            )
+        })
+        req.setTimeout(5000, () => {
+            req.destroy()
+            reject(new Error('CDP 연결 타임아웃'))
+        })
+    })
+}
+
+async function cdpSend(ws, method, params = {}) {
+    const id = Math.floor(Math.random() * 100000)
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error(`CDP 타임아웃: ${method}`)), 30_000)
+
+        const handler = (event) => {
+            const msg = JSON.parse(event.data)
+            if (msg.id === id) {
+                clearTimeout(timeout)
+                ws.removeEventListener('message', handler)
+                if (msg.error) {
+                    reject(new Error(`CDP 에러: ${JSON.stringify(msg.error)}`))
+                } else {
+                    resolve(msg.result)
+                }
+            }
+        }
+
+        ws.addEventListener('message', handler)
+        ws.send(JSON.stringify({id, method, params}))
+    })
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// --- 메인 ---
+async function main() {
+    const args = process.argv.slice(2)
+
+    if (args.length === 0) {
+        console.error('사용법: node scrape-npmx.mjs <패키지명> [패키지명2 ...]')
+        process.exit(1)
+    }
+
+    const targetPackages = [...args]
+    const comparePackages = args.length === 1 ? [...args, DUMMY_PACKAGE] : [...args]
+    const compareUrl = `${NPMX_COMPARE_URL}?packages=${comparePackages.map(encodeURIComponent).join(',')}`
+
+    // 1. 실행 중인 Chrome의 페이지 타겟에 연결
+    const wsUrl = await getPageWebSocketUrl()
+
+    const ws = new WebSocket(wsUrl)
+    await new Promise((resolve, reject) => {
+        ws.onopen = resolve
+        ws.onerror = reject
+    })
+
+    try {
+        // 2. 페이지 이동
+        await cdpSend(ws, 'Page.enable')
+        await cdpSend(ws, 'Page.navigate', {url: compareUrl})
+
+        // 페이지 로드 완료 대기
+        await new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('페이지 로드 타임아웃')), PAGE_LOAD_TIMEOUT)
+            const handler = (event) => {
+                const msg = JSON.parse(event.data)
+                if (msg.method === 'Page.loadEventFired') {
+                    clearTimeout(timeout)
+                    ws.removeEventListener('message', handler)
+                    resolve()
+                }
+            }
+            ws.addEventListener('message', handler)
+        })
+
+        // JS 렌더링 대기
+        await sleep(RENDER_WAIT)
+
+        // 3. DOM에서 데이터 추출
+        const extractScript = `
+        (() => {
+            const result = {};
+            const grid = document.querySelector('.comparison-grid');
+            if (!grid) {
+                return JSON.stringify({ error: 'comparison-grid를 찾을 수 없습니다', rawText: document.body?.innerText?.substring(0, 3000) || '' });
+            }
+
+            // 패키지명 헤더 추출 (.comparison-cell-header 내 a 태그의 title)
+            // title은 "lodash-es@4.17.23" 형태이므로 마지막 @버전을 제거
+            const packageNames = [...grid.querySelectorAll('.comparison-cell-header')]
+                .map(cell => {
+                    const link = cell.querySelector('a[title]');
+                    const raw = link?.title || cell.textContent?.trim() || '';
+                    // @scope/pkg@version → @scope/pkg, pkg@version → pkg
+                    return raw.replace(/@[^@/]+$/, '');
+                })
+                .filter(Boolean);
+
+            // 각 .contents 블록에서 메트릭 추출
+            const metrics = {};
+            grid.querySelectorAll('.contents').forEach(block => {
+                // 메트릭명: .comparison-label > span
+                const label = block.querySelector('.comparison-label span')?.textContent?.trim();
+                if (!label) return;
+
+                // 값: 각 .comparison-cell 에서 추출
+                const values = [...block.querySelectorAll('.comparison-cell:not(.comparison-cell-header)')].map(cell => {
+                    // time 요소 우선 (Published 등)
+                    const time = cell.querySelector('time');
+                    if (time) return time.getAttribute('title') || time.textContent?.trim() || 'N/A';
+
+                    // span[dir="auto"] (일반 값)
+                    const valueSpan = cell.querySelector('span[dir="auto"]');
+                    if (valueSpan) return valueSpan.textContent?.trim() || 'N/A';
+
+                    // "-" 표시 (데이터 없음)
+                    const muted = cell.querySelector('.text-fg-subtle');
+                    if (muted) return muted.textContent?.trim() || '-';
+
+                    return 'N/A';
+                });
+
+                metrics[label] = values;
+            });
+
+            // 패키지별로 구조화
+            const packages = {};
+            packageNames.forEach((pkg, idx) => {
+                packages[pkg] = {};
+                for (const [key, values] of Object.entries(metrics)) {
+                    packages[pkg][key] = values[idx] || 'N/A';
+                }
+            });
+
+            result.packages = packages;
+            result.url = window.location.href;
+            return JSON.stringify(result);
+        })()
+        `
+
+        const evalResult = await cdpSend(ws, 'Runtime.evaluate', {
+            expression: extractScript,
+            returnByValue: true,
+        })
+
+        const data = JSON.parse(evalResult.result.value)
+
+        // 단일 패키지 평가인 경우 더미 패키지 제거
+        if (args.length === 1 && data.packages) {
+            delete data.packages[DUMMY_PACKAGE]
+        }
+
+        // 대상 패키지만 필터
+        if (data.packages) {
+            const filtered = {}
+            for (const pkg of targetPackages) {
+                if (data.packages[pkg]) {
+                    filtered[pkg] = data.packages[pkg]
+                }
+            }
+            data.packages = filtered
+        }
+
+        // 4. 결과 출력
+        console.log(JSON.stringify(data, null, 2))
+    } finally {
+        ws.close()
+    }
+}
+
+main().catch((err) => {
+    console.error(JSON.stringify({error: err.message}))
+    process.exit(1)
+})

--- a/plugins/package-evaluator/scripts/scrape-npmx.mjs
+++ b/plugins/package-evaluator/scripts/scrape-npmx.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * npmx.dev Compare 페이지에서 패키지 메트릭을 CDP로 스크래핑합니다.
+ * npmx.dev Compare 페이지에서 패키지 메트릭을 CDP Accessibility Tree로 스크래핑합니다.
+ *
+ * DOM 셀렉터 대신 접근성 트리(AXTree)를 사용하여
+ * CSS 클래스 변경에 영향받지 않는 안정적인 데이터 추출을 합니다.
  *
  * 사전조건:
  *   Chrome/Chromium이 --remote-debugging-port=9222로 실행 중이어야 합니다.
@@ -89,6 +92,70 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+// --- AXTree 파싱 ---
+function extractFromAXTree(nodes) {
+    // COMPARISON 영역의 구조를 활용:
+    //   InlineTextBox name="METRIC NAME"   ← 메트릭 라벨
+    //   generic       desc="pkg@version"   ← 패키지 식별
+    //   StaticText    name="value"          ← 값 (또는 time desc="date")
+    //   generic       desc="pkg@version"   ← 다음 패키지
+    //   StaticText    name="value"          ← 값
+    //   InlineTextBox name="NEXT METRIC"   ← 다음 메트릭
+    //
+    // 앵커 포인트 없이, generic[desc] 패턴으로 패키지-메트릭-값을 직접 매핑
+
+    // COMPARISON heading 이후 노드만 탐색
+    const compIdx = nodes.findIndex(
+        (n) => n.role?.value === 'heading' && n.name?.value === 'COMPARISON',
+    )
+    if (compIdx === -1) {
+        return {error: 'AXTree에서 COMPARISON 영역을 찾을 수 없습니다'}
+    }
+
+    const packages = {}
+    let currentMetric = null
+
+    for (let i = compIdx + 1; i < nodes.length; i++) {
+        const node = nodes[i]
+        const role = node.role?.value
+        const name = node.name?.value || ''
+        const desc = node.description?.value || ''
+
+        // 다음 heading이 나오면 COMPARISON 영역 종료
+        if (role === 'heading') break
+
+        // InlineTextBox = 메트릭 라벨
+        if (role === 'InlineTextBox' && name) {
+            currentMetric = name
+            continue
+        }
+
+        // generic + desc="pkg@version" = 패키지 셀 시작
+        if (role === 'generic' && desc && /@\d/.test(desc)) {
+            const pkgName = desc.replace(/@[^@/]+$/, '')
+            if (!packages[pkgName]) packages[pkgName] = {}
+
+            // 이후 노드에서 값 추출 (StaticText 또는 time, 빈 노드 건너뜀)
+            for (let j = i + 1; j < Math.min(i + 5, nodes.length); j++) {
+                const vNode = nodes[j]
+                const vRole = vNode.role?.value
+                const vName = vNode.name?.value || ''
+                const vDesc = vNode.description?.value || ''
+
+                if (vRole === 'time') {
+                    packages[pkgName][currentMetric] = vDesc || vName || 'N/A'
+                    break
+                } else if (vRole === 'StaticText' && vName) {
+                    packages[pkgName][currentMetric] = vName
+                    break
+                }
+            }
+        }
+    }
+
+    return {packages}
+}
+
 // --- 메인 ---
 async function main() {
     const args = process.argv.slice(2)
@@ -102,9 +169,8 @@ async function main() {
     const comparePackages = args.length === 1 ? [...args, DUMMY_PACKAGE] : [...args]
     const compareUrl = `${NPMX_COMPARE_URL}?packages=${comparePackages.map(encodeURIComponent).join(',')}`
 
-    // 1. 실행 중인 Chrome의 페이지 타겟에 연결
+    // 1. Chrome 페이지 타겟 연결
     const wsUrl = await getPageWebSocketUrl()
-
     const ws = new WebSocket(wsUrl)
     await new Promise((resolve, reject) => {
         ws.onopen = resolve
@@ -133,74 +199,14 @@ async function main() {
         // JS 렌더링 대기
         await sleep(RENDER_WAIT)
 
-        // 3. DOM에서 데이터 추출
-        const extractScript = `
-        (() => {
-            const result = {};
-            const grid = document.querySelector('.comparison-grid');
-            if (!grid) {
-                return JSON.stringify({ error: 'comparison-grid를 찾을 수 없습니다', rawText: document.body?.innerText?.substring(0, 3000) || '' });
-            }
+        // 3. Accessibility Tree 추출
+        await cdpSend(ws, 'Accessibility.enable')
+        const axResult = await cdpSend(ws, 'Accessibility.getFullAXTree')
 
-            // 패키지명 헤더 추출 (.comparison-cell-header 내 a 태그의 title)
-            // title은 "lodash-es@4.17.23" 형태이므로 마지막 @버전을 제거
-            const packageNames = [...grid.querySelectorAll('.comparison-cell-header')]
-                .map(cell => {
-                    const link = cell.querySelector('a[title]');
-                    const raw = link?.title || cell.textContent?.trim() || '';
-                    // @scope/pkg@version → @scope/pkg, pkg@version → pkg
-                    return raw.replace(/@[^@/]+$/, '');
-                })
-                .filter(Boolean);
-
-            // 각 .contents 블록에서 메트릭 추출
-            const metrics = {};
-            grid.querySelectorAll('.contents').forEach(block => {
-                // 메트릭명: .comparison-label > span
-                const label = block.querySelector('.comparison-label span')?.textContent?.trim();
-                if (!label) return;
-
-                // 값: 각 .comparison-cell 에서 추출
-                const values = [...block.querySelectorAll('.comparison-cell:not(.comparison-cell-header)')].map(cell => {
-                    // time 요소 우선 (Published 등)
-                    const time = cell.querySelector('time');
-                    if (time) return time.getAttribute('title') || time.textContent?.trim() || 'N/A';
-
-                    // span[dir="auto"] (일반 값)
-                    const valueSpan = cell.querySelector('span[dir="auto"]');
-                    if (valueSpan) return valueSpan.textContent?.trim() || 'N/A';
-
-                    // "-" 표시 (데이터 없음)
-                    const muted = cell.querySelector('.text-fg-subtle');
-                    if (muted) return muted.textContent?.trim() || '-';
-
-                    return 'N/A';
-                });
-
-                metrics[label] = values;
-            });
-
-            // 패키지별로 구조화
-            const packages = {};
-            packageNames.forEach((pkg, idx) => {
-                packages[pkg] = {};
-                for (const [key, values] of Object.entries(metrics)) {
-                    packages[pkg][key] = values[idx] || 'N/A';
-                }
-            });
-
-            result.packages = packages;
-            result.url = window.location.href;
-            return JSON.stringify(result);
-        })()
-        `
-
-        const evalResult = await cdpSend(ws, 'Runtime.evaluate', {
-            expression: extractScript,
-            returnByValue: true,
-        })
-
-        const data = JSON.parse(evalResult.result.value)
+        // 4. 패키지 데이터 추출
+        const data = extractFromAXTree(axResult.nodes)
+        data.url = compareUrl
+        data.method = 'accessibility-tree'
 
         // 단일 패키지 평가인 경우 더미 패키지 제거
         if (args.length === 1 && data.packages) {
@@ -218,7 +224,7 @@ async function main() {
             data.packages = filtered
         }
 
-        // 4. 결과 출력
+        // 5. 결과 출력
         console.log(JSON.stringify(data, null, 2))
     } finally {
         ws.close()


### PR DESCRIPTION
## Related Issue

- 없음

## Describe your changes

npmx.dev 데이터 기반으로 npm 패키지 도입 전 자동 평가하는 package-evaluator 플러그인을 추가합니다.

- package-evaluator 플러그인 구조 추가 (plugin.json, README, evaluate-package 커맨드)
- CDP Accessibility Tree 기반 npmx.dev 스크래핑 스크립트 (`scrape-npmx.mjs`)
- marketplace.json에 플러그인 등록 및 루트 README에 링크 추가

## Request

- CDP(Chrome DevTools Protocol) + Accessibility Tree 기반 스크래핑 방식이 적절한지 검토 부탁드립니다
- 평가 기준(즉시 거부 / 경고 / 양호 조건)이 합리적인지 확인 부탁드립니다

## CDP 선택 근거

1. **단일 데이터 소스로 모든 메트릭 수집** — npmx.dev compare 페이지 한 번 로드로 번들 사이즈, 의존성 수, 다운로드 수, 취약점, 타입 지원, 라이선스 등 필요한 모든 메트릭을 한꺼번에 가져옴. npm registry API를 개별 호출하면 여러 엔드포인트를 조합해야 하고 속도 면에서도 불리함.
2. **사내 레지스트리 한계 우회** — 사내 npm registry에는 `npm audit` 같은 보안 취약점 조회 기능이 없음. npmx.dev는 이미 이 데이터를 집계해서 보여주기 때문에, CDP로 스크래핑하면 환경(사내/공개)에 구애받지 않고 동일한 평가 가능.
3. **npmx.dev 비교 기능 활용** — compare 페이지를 활용하면 여러 패키지를 한 화면에서 비교 평가 가능. 단일 패키지 평가 시에는 dummy 패키지(react)를 함께 넣고 결과에서 필터링.
4. **별도 의존성 불필요** — Node.js 22+ 내장 WebSocket만 사용하므로 puppeteer, playwright 같은 무거운 브라우저 자동화 라이브러리나 `ws` 패키지 없이 동작.

## Accessibility Tree 선택 근거

초기에는 DOM CSS 셀렉터(`.comparison-grid`, `.comparison-cell-header` 등)로 구현했으나, npmx.dev가 아직 활발히 개발 중이라 DOM 구조 변경 시 스크립트 깨질 가능성이 높아 AXTree로 전환했습니다.

- **CSS 클래스 의존 0개** — DOM 셀렉터 방식은 6개+ 클래스에 의존했으나, AXTree는 브라우저가 생성하는 시맨틱 구조(role, name, description)를 활용
- **고정 앵커 문자열 0개** — `generic[desc="pkg@version"]` 패턴으로 패키지-메트릭-값을 직접 매핑
- **메트릭 추가/삭제/순서 변경에 자동 대응** — 헤더-값 블록을 동적으로 파싱

rawText(innerText + Claude 파싱) 방식도 검토했으나, 파싱 주체가 Claude에 의존하게 되어 결과 일관성 면에서 AXTree를 선택.

## CDP 실행 순서

동기 파이프라인 — 각 단계가 이전 결과에 의존하므로 비동기화 이점 없음.

```
1. localhost:9222/json/list → 페이지 타겟 WebSocket URL 획득
2. WebSocket 연결
3. Page.enable → 페이지 이벤트 활성화
4. Page.navigate → npmx.dev compare 페이지로 이동
5. Page.loadEventFired 대기 → 페이지 로드 완료
6. 5초 대기 → SPA 렌더링 완료 대기
7. Accessibility.enable + getFullAXTree → 접근성 트리 추출
8. AXTree 파싱 → 패키지별 메트릭 JSON 구성
9. WebSocket 종료
10. 결과 JSON 출력
```